### PR TITLE
[#237, #241] Add tests and change rename methodology

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
         "fkey",
         "graphlib",
         "Hirokit",
+        "Insomnium",
         "Jkwok",
         "maxsize",
         "Muzaque",

--- a/h-util-ui/Electron/operations/modules/fileSanitize.handler.spec.ts
+++ b/h-util-ui/Electron/operations/modules/fileSanitize.handler.spec.ts
@@ -1,0 +1,108 @@
+import fileSanitize from './fileSanitize.handler';
+
+const moduleHandler = fileSanitize.handler!;
+
+jest.mock('@common/fileops', () => ({
+    getExt: jest.fn((filename: string) => filename.split('.').pop()),
+    splitFileNameFromPath: jest.fn((filePath: string) => {
+        const split = filePath.split('/');
+
+        if (split.length < 1) throw new Error('Invalid name');
+
+        const fileName = split.pop()!;
+        return {
+            fileName,
+            rootPath: split.join('/'),
+        };
+    }),
+}));
+jest.mock('fs/promises', () => ({
+    rename: jest.fn(),
+    access: jest.fn(),
+}));
+
+import * as handlerHelpers from '../handler.helpers';
+
+jest.mock('../handler.helpers', () => {
+    const originalModule = jest.requireActual('../handler.helpers');
+    return {
+        ...originalModule,
+        addEventLogForReport: jest.fn(),
+    };
+});
+
+describe('fileNameSafeTitleReplace', () => {
+    const cases = [
+        {
+            originalFileName: 'Video_笑谈广州话.mp4',
+            expectedFileName: 'Video______.mp4',
+        },
+        {
+            originalFileName: "Test's Invalid Junk!.doc",
+            expectedFileName: 'Test_s Invalid Junk_.doc',
+        },
+        {
+            originalFileName: 'hello世界.cpp',
+            expectedFileName: 'hello__.cpp',
+        },
+    ];
+
+    it.each(cases)(
+        'should rename file with sanitized title: $originalFileName -> $expectedFileName',
+        async ({ originalFileName, expectedFileName }) => {
+            const result = moduleHandler(
+                { filePath: `/path/to/${originalFileName}` },
+                {
+                    clientOptions: { value: '_' },
+                    filePath: `/path/to/${originalFileName}`,
+                } as any,
+                {},
+            );
+
+            await result;
+
+            expect(handlerHelpers.addEventLogForReport).toHaveBeenCalledWith(
+                expect.anything(),
+                originalFileName,
+                'renamed',
+                expectedFileName,
+            );
+        },
+    );
+
+    it('should handle name collisions by appending a counter', async () => {
+        const { access } = require('fs/promises');
+
+        (handlerHelpers.addEventLogForReport as jest.Mock).mockClear();
+
+        let times = 0;
+        // Simulate that the first sanitized name already exists, but the second does not
+        access.mockImplementation(
+            () =>
+                new Promise<boolean>((resolve, reject) => {
+                    if (times > 0) return reject(); // File does not exist
+                    times++;
+                    resolve(true);
+                }),
+        );
+
+        const originalFileName = 'Test:________File?.txt';
+        const expectedFinalName = 'Test_________File_._1.txt';
+
+        await moduleHandler(
+            { filePath: `/path/to/${originalFileName}` },
+            {
+                clientOptions: { value: '_' },
+                filePath: `/path/to/${originalFileName}`,
+            } as any,
+            {},
+        );
+
+        expect(handlerHelpers.addEventLogForReport).toHaveBeenCalledWith(
+            expect.anything(),
+            originalFileName,
+            'renamed',
+            expectedFinalName,
+        );
+    });
+});

--- a/h-util-ui/Electron/operations/modules/nameTag.handler.ts
+++ b/h-util-ui/Electron/operations/modules/nameTag.handler.ts
@@ -31,6 +31,7 @@ const nameTagHandler: ModuleHandler = {
 
         if (!fileName) return;
 
+        /** Parsed from filename */
         const parsedTags = parseStringToTags(pattern, removeExt(fileName));
 
         if (!parsedTags) return;
@@ -38,8 +39,8 @@ const nameTagHandler: ModuleHandler = {
         await withUTimes(async () => {
             const readTags = (await ffMeta.readTags(filePath)) as TagReturnType;
             const existingTitle = readTags.format?.tags?.title || '';
-            const withMetaDataTitle = fileNameSafeTitleReplace(parsedTags.title, existingTitle);
-            parsedTags.title = withMetaDataTitle;
+            const unSafeTitleForTag = fileNameSafeTitleReplace(parsedTags.title, existingTitle);
+            parsedTags.title = unSafeTitleForTag;
 
             await ffMeta.writeTags(filePath, { ...parsedTags });
             await replaceFile(filePath, getTempName(filePath));

--- a/h-util-ui/Electron/operations/modules/nameTag.helpers.spec.ts
+++ b/h-util-ui/Electron/operations/modules/nameTag.helpers.spec.ts
@@ -1,41 +1,100 @@
 import { fileNameSafeTitleReplace } from './nameTag.helpers';
+import { parseStringToTags } from '@common/fileops';
 
 describe('fileNameSafeTitleReplace', () => {
-    it('returns original filename if fileSafeTitle equals metadataTitle', () => {
-        const result = fileNameSafeTitleReplace('my_file.txt', 'my_file.txt');
-        expect(result).toBe('my_file.txt');
+    const cases = [
+        {
+            desc: 'returns original filename if fileSafeTitle equals metadataTitle',
+            filename: 'my_file.txt',
+            metadataTitle: 'my_file.txt',
+            expected: 'my_file.txt',
+        },
+        {
+            desc: 'returns original filename if fileSafeFilename does not include fileSafeTitle',
+            filename: 'abc_def.txt',
+            metadataTitle: 'xyz',
+            expected: 'abc_def.txt',
+        },
+        {
+            desc: 'replaces fileSafeTitle in filename with metadataTitle',
+            filename: 'my_title_file.txt',
+            metadataTitle: 'title',
+            expected: 'my_title_file.txt'.replace('title', 'title'),
+        },
+        {
+            desc: 'replaces fileSafeTitle in filename with metadataTitle (with spaces)',
+            filename: 'my_title_file.txt',
+            metadataTitle: 'title',
+            expected: 'my_title_file.txt'.replace('title', 'title'),
+        },
+        {
+            desc: 'returns original filename if fileSafeTitle not found in fileSafeFilename',
+            filename: 'my_file.txt',
+            metadataTitle: 'notfound',
+            expected: 'my_file.txt',
+        },
+        {
+            desc: 'handles empty filename and metadataTitle',
+            filename: '',
+            metadataTitle: '',
+            expected: '',
+        },
+    ];
+
+    it.each(cases)('normal case: $desc', ({ filename, metadataTitle, expected }) => {
+        const result = fileNameSafeTitleReplace(filename, metadataTitle);
+        expect(result).toBe(expected);
     });
 
-    it('returns original filename if fileSafeFilename does not include fileSafeTitle', () => {
-        const result = fileNameSafeTitleReplace('abc_def.txt', 'xyz');
-        expect(result).toBe('abc_def.txt');
-    });
+    // Bug cases from real world usage
+    const bugCases = [
+        {
+            filename: 'How Short Is Japan’s Shortest Railway_ - 2026.txt',
+            metadataTitle: 'How Short Is Japan’s Shortest Railway?',
+            expected: 'How Short Is Japan’s Shortest Railway? - 2026.txt',
+        },
+        {
+            filename: 'What’s Life Like in Hong Kong in 2024_ _ Street Interview - 2024.txt',
+            metadataTitle: 'What’s Life Like in Hong Kong in 2024? | Street Interview',
+            expected: 'What’s Life Like in Hong Kong in 2024? | Street Interview - 2024.txt',
+        },
+        {
+            filename: 'China’s Strangest Mountain_ 3m Wide Like a Wall, Cliff Edge Thrill! - 2025-04-12.txt',
+            metadataTitle: 'China’s Strangest Mountain? 3m Wide Like a Wall, Cliff Edge Thrill!',
+            expected: 'China’s Strangest Mountain? 3m Wide Like a Wall, Cliff Edge Thrill! - 2025-04-12.txt',
+        },
+        {
+            filename: '___________ — ____ ___ - 2017-10-03.txt',
+            metadataTitle: '【笑谈广州话】粤语拼音 — 九声六调 第二集',
+            expected: '【笑谈广州话】粤语拼音 — 九声六调 第二集 - 2017-10-03.txt',
+        },
+    ];
 
-    it('returns metadataTitle if too many replacement characters', () => {
-        // filename has 6 underscores out of 12 chars (40%)
-        const result = fileNameSafeTitleReplace('a_____b___c_d_e_f.txt', 'a?????b???c?d?e?f');
-        expect(result).toBe('a?????b???c?d?e?f');
+    it.each(bugCases)('bug case: $expected', ({ filename, metadataTitle, expected }) => {
+        const result = fileNameSafeTitleReplace(filename, metadataTitle);
+        expect(result).toBe(expected);
     });
+});
 
-    it('replaces fileSafeTitle in filename with metadataTitle', () => {
-        // fileSafeFilename: "my_title_file.txt", fileSafeTitle: "title"
-        const result = fileNameSafeTitleReplace('my_title_file.txt', 'title');
-        expect(result).toBe('my_title_file.txt'.replace('title', 'title'));
-    });
+describe('parseStringToTags', () => {
+    const pattern = '%artist% - %title%';
 
-    it('replaces fileSafeTitle in filename with metadataTitle (with spaces)', () => {
-        // fileSafeFilename: "my_title_file.txt", fileSafeTitle: "title"
-        const result = fileNameSafeTitleReplace('my_title_file.txt', 'title');
-        expect(result).toBe('my_title_file.txt'.replace('title', 'title'));
-    });
+    const cases = [
+        {
+            input: 'Insomnium - While We Sleep',
+            expected: { artist: 'Insomnium', title: 'While We Sleep' },
+        },
+        {
+            input: "Insomnium - Winter's Gate - pt. 2 - 2022-09-11",
+            expected: {
+                artist: 'Insomnium',
+                title: "Winter's Gate - pt. 2 - 2022-09-11",
+            },
+        },
+    ];
 
-    it('returns original filename if fileSafeTitle not found in fileSafeFilename', () => {
-        const result = fileNameSafeTitleReplace('my_file.txt', 'notfound');
-        expect(result).toBe('my_file.txt');
-    });
-
-    it('handles empty filename and metadataTitle', () => {
-        const result = fileNameSafeTitleReplace('', '');
-        expect(result).toBe('');
+    it.each(cases)('should parse %input to tags correctly', ({ input, expected }) => {
+        const result = parseStringToTags(pattern, input);
+        expect(result).toEqual(expected);
     });
 });

--- a/h-util-ui/Electron/operations/modules/nameTag.helpers.ts
+++ b/h-util-ui/Electron/operations/modules/nameTag.helpers.ts
@@ -3,16 +3,27 @@ import { sanitizeStringForFilename } from '../handler.helpers';
 const replacementCharacter = '_';
 
 export const fileNameSafeTitleReplace = (filename: string, metadataTitle: string): string => {
-    const fileSafeFilename = sanitizeStringForFilename(filename, replacementCharacter);
     const fileSafeTitle = sanitizeStringForFilename(metadataTitle, replacementCharacter);
 
-    if (fileSafeTitle === metadataTitle) return filename; // No change needed
+    if (fileSafeTitle === metadataTitle || filename === metadataTitle) return filename; // No change needed
 
-    if (!fileSafeFilename.includes(fileSafeTitle)) return filename; // No match found
+    const newFilename = filename.replace(fileSafeTitle, metadataTitle);
 
-    const replacementCharCount = (filename.match(new RegExp(replacementCharacter, 'g')) || []).length;
-
-    if (filename.length > 10 && replacementCharCount / filename.length > 0.4) return metadataTitle; // Too many replacement characters
-
-    return filename.replace(fileSafeTitle, metadataTitle);
+    /**
+     * Merge the two strings by replacing replacementCharacter in newFilename with corresponding characters from metadata.
+     * This is a final check to make sure we don't have lingering replacement characters.
+     */
+    const minLength = Math.min(newFilename.length, metadataTitle.length);
+    let reconstructed = '';
+    for (let i = 0; i < minLength; i++) {
+        reconstructed +=
+            newFilename[i] === replacementCharacter && metadataTitle[i] !== replacementCharacter
+                ? metadataTitle[i]
+                : newFilename[i];
+    }
+    // Optionally, append the rest if newFilename is longer
+    if (newFilename.length > minLength) {
+        reconstructed += newFilename.slice(minLength);
+    }
+    return reconstructed;
 };

--- a/h-util-ui/readme.md
+++ b/h-util-ui/readme.md
@@ -1,4 +1,4 @@
-# H-Util UI
+# Acqua Claudia (H-Util UI)
 
 A UI version of H-util to support dragging and dropping files and pipeline building.
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -157,10 +157,7 @@ const config: Config = {
     // testLocationInResults: false,
 
     // The glob patterns Jest uses to detect test files
-    // testMatch: [
-    //   "**/__tests__/**/*.?([mc])[jt]s?(x)",
-    //   "**/?(*.)+(spec|test).?([mc])[jt]s?(x)"
-    // ],
+    testMatch: ['**/h-util-ui/**/*.spec.?([mc])[jt]s?(x)'],
 
     // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
     // testPathIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Turns some common data operations into a CLI tool, to prevent needing various third party apps and utilities and configs. This includes:",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "jest ./h-util-ui",
     "build": "tsc --build --verbose",
     "build:common": "npm run build --workspace ./packages/common",
     "build:fileops": "npm run build --workspace ./packages/fileops"


### PR DESCRIPTION
Adds a number of unit tests and adjusts the renamer helper to use a character comparison approach.

Resolves #237 
Resolves #241