### PR TITLE
Mirror title logic for nameTag artist

### DIFF
--- a/h-util-ui/Electron/operations/modules/nameTag.handler.ts
+++ b/h-util-ui/Electron/operations/modules/nameTag.handler.ts
@@ -41,6 +41,7 @@ const nameTagHandler: ModuleHandler = {
             const existingTitle = readTags.format?.tags?.title || '';
             const unSafeTitleForTag = fileNameSafeTitleReplace(parsedTags.title, existingTitle);
             parsedTags.title = unSafeTitleForTag;
+            parsedTags.artist = fileNameSafeTitleReplace(parsedTags.artist, readTags.format?.tags?.artist || '');
 
             await ffMeta.writeTags(filePath, { ...parsedTags });
             await replaceFile(filePath, getTempName(filePath));


### PR DESCRIPTION
Fixes an issue where an artist may be all replacement characters if the original filename artist were eligible for simplification. 