### PR TITLE
[#174] Repurpose About modal

### DIFF
--- a/h-util-ui/client/src/components/Internals/Internals.vue
+++ b/h-util-ui/client/src/components/Internals/Internals.vue
@@ -6,6 +6,7 @@ import store from '@utils/store';
 import InternalsCards from './InternalsCards.vue';
 import { watch } from 'vue';
 import { useQuasar } from 'quasar'
+import StatsWrapper from './Subsections/StatsWrapper.vue';
 
 const handleChangeCardStyle = store.setCardStyles;
 const $q = useQuasar();
@@ -34,6 +35,14 @@ watch(() => store.state.settings.darkMode, () => {
 
             <q-toggle :model-value="store.state.settings.darkMode" @update:model-value="store.toggleDarkMode"
               label="Dark mode" />
+          </template>
+        </InternalsCards>
+        <InternalsCards>
+          <template #headers>
+            Stats
+          </template>
+          <template #content>
+            <StatsWrapper />
           </template>
         </InternalsCards>
         <InternalsCards>

--- a/h-util-ui/client/src/components/Internals/Subsections/StatsDisplay.vue
+++ b/h-util-ui/client/src/components/Internals/Subsections/StatsDisplay.vue
@@ -15,13 +15,13 @@ const totalFiles = computed(() => stats.reduce((a, v) => a + v.filesProcessed, 0
 </script>
 
 <template>
-  <h4>Pipeline invocations</h4>
+  <b>Pipeline invocations</b>
   <div class="pipeline-stats">
     <div v-for="pipeline in pipelineRunData">
       {{ pipeline.pipelineName }} : {{ pipeline.timesRan }}
     </div>
   </div>
-  <h4>Other</h4>
+  <b>Other</b>
   <div>
     Time spent processing: {{ formatMilliseconds(totalTime) }}
   </div>

--- a/h-util-ui/client/src/components/Internals/Subsections/StatsWrapper.vue
+++ b/h-util-ui/client/src/components/Internals/Subsections/StatsWrapper.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue';
+import StatsDisplay from 'src/components/Internals/Subsections/StatsDisplay.vue';
+import { PipelineStatsPayload } from '@shared/common.types';
+import { models } from 'src/data/models';
+
+const stats = ref<PipelineStatsPayload[] | null>(null);
+
+const getStats = () => {
+  const data = models.stats.selectAll();
+  stats.value = data;
+}
+
+onMounted(() => {
+  getStats();
+});
+</script>
+
+<template>
+  <StatsDisplay v-if="stats" :stats="stats" />
+</template>

--- a/h-util-ui/client/src/components/about/AboutModal.vue
+++ b/h-util-ui/client/src/components/about/AboutModal.vue
@@ -49,6 +49,11 @@ defineProps<{
       </q-card-section>
 
       <q-card-section v-if="tab === Tabs.usage">
+        Primary functions:
+        <ul>
+          <li>Pipelines: Define a series of processing steps for your files</li>
+          <li>Aqueducts: Attach a pipeline to a specified directory for routine jobs on files present</li>
+        </ul>
         Notes on some of the trickier modules and their usage:
         <ul>
           <li>Filter modules: filter files from rest of the pipeline</li>

--- a/h-util-ui/client/src/components/about/AboutModal.vue
+++ b/h-util-ui/client/src/components/about/AboutModal.vue
@@ -1,59 +1,60 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
-import { PipelineStatsPayload } from '@shared/common.types';
-import StatsDisplay from './StatsDisplay.vue';
-import { models } from 'src/data/models';
+import { ref } from 'vue';
 
 enum Tabs {
-  stats = 'stat',
+  usage = 'usage',
   about = 'about',
 }
 
 const tab = ref(Tabs.about);
 const about = ref(false);
-const stats = ref<PipelineStatsPayload[] | null>(null);
 
 defineProps<{
   openButton: any;
   openButtonProps?: Record<string, any>;
 }>();
 
-const getStats = () => {
-  const data = models.stats.selectAll();
-  stats.value = data;
-}
 
-watch(about, (newValue, oldValue) => {
-  /** Only fetch when opening */
-  if (newValue && !oldValue) getStats();
-})
 </script>
 
 <template>
   <component class="icon-button" @click="about = true" :is="openButton" v-bind="openButtonProps ?? {}" />
 
   <q-dialog v-model="about" backdrop-filter="blur(5px)">
-    <q-card>
+    <q-card class="about-card">
       <q-card-section style="width: 70vw;">
         <div class="text-h6">About</div>
       </q-card-section>
 
       <q-tabs v-model="tab">
         <q-tab name="about" label="About" />
-        <q-tab name="stat" label="Stats" />
+        <q-tab name="usage" label="Modules" />
       </q-tabs>
 
-      <q-card-section v-if="tab === Tabs.stats">
-        <StatsDisplay v-if="stats" :stats="stats" />
+      <q-card-section v-if="tab === Tabs.about">
+        <div class="text-subtitle1">H-Util Visual</div>
+        <div class="text-caption">
+          A visual interface for the Hoarder-Util CLI tool. It allows you to run pipelines, view stats, and manage your
+          files.
+
+          <br />
+          <br />
+          The original CLI tool is no longer maintained, but should operate as expected. This was meant as a
+          personal-use utility, so in many places design and UX may not be optimal.
+          <br />
+          <br />
+
+          Developed by <a href="https://github.com/TestaDiMucca">我係「牛頭」</a> 2024
+        </div>
       </q-card-section>
 
-      <q-card-section v-if="tab === Tabs.about">
-        H-Util Visual
-
-        Notes on usage:
+      <q-card-section v-if="tab === Tabs.usage">
+        Notes on some of the trickier modules and their usage:
         <ul>
-          <li>Filter modules filter files from rest of the pipeline</li>
-          <li></li>
+          <li>Filter modules: filter files from rest of the pipeline</li>
+          <li>Branch: construct rules to control the flow of files through the pipeline</li>
+          <li>Metadata tagging: A static operation which parses a filename into video metadata</li>
+          <li>Delete: Use with caution as any file not filtered out from the pipeline will be trashed</li>
         </ul>
 
       </q-card-section>
@@ -64,3 +65,9 @@ watch(about, (newValue, oldValue) => {
     </q-card>
   </q-dialog>
 </template>
+
+<style scoped>
+.about-card {
+  overflow-x: hidden;
+}
+</style>


### PR DESCRIPTION
Puts more about-y information into About, moving stats to the internals and settings bit.

<img width="491" alt="Screenshot 2025-07-06 at 9 00 00 AM" src="https://github.com/user-attachments/assets/e37fa9fb-f172-477a-8dd1-95fc7e7c8ab6" />



Resolves #174